### PR TITLE
plan9 support

### DIFF
--- a/lock_plan9.go
+++ b/lock_plan9.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2013 The Go Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lock
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func init() {
+	lockFn = lockPlan9
+}
+
+func lockPlan9(name string) (io.Closer, error) {
+	var f *os.File
+	abs, err := filepath.Abs(name)
+	if err != nil {
+		return nil, err
+	}
+	lockmu.Lock()
+	if locked[abs] {
+		lockmu.Unlock()
+		return nil, fmt.Errorf("file %q already locked", abs)
+	}
+	locked[abs] = true
+	lockmu.Unlock()
+
+	fi, err := os.Stat(name)
+	if err == nil && fi.Size() > 0 {
+		return nil, fmt.Errorf("can't Lock file %q: has non-zero size", name)
+	}
+
+	f, err = os.OpenFile(name, os.O_RDWR|os.O_CREATE, os.ModeExclusive|0644)
+	if err != nil {
+		return nil, fmt.Errorf("Lock Create of %s (abs: %s) failed: %v", name, abs, err)
+	}
+
+	return &unlocker{f, abs}, nil
+}


### PR DESCRIPTION
bmo% go test -run 'TestLock$' -v
=== RUN TestLock
--- PASS: TestLock (0.22s)
    lock_test.go:94: Locking in crashing child...
    lock_test.go:87: Child output: "" (err <nil>)
    lock_test.go:99: Locking+unlocking in child...
    lock_test.go:87: Child output: "PASS\n" (err <nil>)
    lock_test.go:104: Locking in parent...
    lock_test.go:110: Again in parent...
    lock_test.go:116: Locking in child...
    lock_test.go:87: Child output: "2014/07/27 21:48:05 Lock failed: Lock Create of /tmp/748837139/foo.lock (abs: /tmp/748837139/foo.lock) failed: open /tmp/748837139/foo.lock: '/tmp/748837139/foo.lock' open/create -- file is locked\n" (err exit status: 'lock.test 152796: 1')
    lock_test.go:121: Unlocking lock in parent
PASS
ok      github.com/camlistore/lock  0.242s
